### PR TITLE
Add versioned internal policy APIs with global internal mTLS security and codex context pack

### DIFF
--- a/.github/workflows/context-sync.yml
+++ b/.github/workflows/context-sync.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -33,6 +34,11 @@ jobs:
 
       - name: Run context sync check (script)
         run: ./scripts/check-context-sync.sh
+
+      - name: Verify local modules
+        run: |
+          test -f mangala-common-security/pom.xml
+          test -f mangala-exception/pom.xml
 
       - name: Install local dependency modules
         run: |

--- a/.github/workflows/context-sync.yml
+++ b/.github/workflows/context-sync.yml
@@ -1,0 +1,43 @@
+name: Context Sync Check
+
+on:
+  pull_request:
+    paths:
+      - 'src/main/java/**'
+      - 'src/main/resources/migration/**'
+      - 'docs/**'
+      - 'AGENTS.md'
+      - 'scripts/check-context-sync.sh'
+      - 'pom.xml'
+  workflow_dispatch:
+
+jobs:
+  context-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Ensure script executable
+        run: chmod +x scripts/check-context-sync.sh
+
+      - name: Run context sync check (script)
+        run: ./scripts/check-context-sync.sh
+
+      - name: Install local dependency modules
+        run: |
+          mvn -B -q -f mangala-common-security/pom.xml install -DskipTests
+          mvn -B -q -f mangala-exception/pom.xml install -DskipTests
+
+      - name: Run context sync check (maven profile)
+        run: mvn -B -q -Pcontext-check validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Purpose
+This file is the fast bootstrap context for contributors and coding agents.
+Read this first before scanning the whole codebase.
+
+## Service Scope
+- Service: `mangala-authentication`
+- Base package: `org.mangala.authentication`
+- Main class: `src/main/java/org/mangala/authentication/MainApplication.java`
+
+## Architecture Conventions
+- Feature-first packages: `auth`, `passkey`, `user`, `policy`, `shared`.
+- Layering per feature:
+  - `adapter/web`: controllers, request/response DTOs, web mappers
+  - `usecase`: application services (`XxxUseCase`, `XxxUseCaseImpl`)
+  - `usecase/command`: input models (records/builders)
+  - `usecase/model`: output models (records)
+  - `domain`: entities + domain exceptions
+  - `adapter/repository`: Spring Data repositories
+
+## Naming Conventions
+- Java fields/methods/variables: `camelCase`.
+- DB column names remain snake_case via `@Column(name = "...")`.
+- UseCase pair naming:
+  - Interface: `XxxUseCase`
+  - Implementation: `XxxUseCaseImpl`
+- Web DTOs:
+  - Request: `...RequestDTO`
+  - Response: `...ResponseDTO`
+
+## Error Handling
+- Domain/business exceptions extend `org.mangala.exception.BaseException`.
+- Error definitions must be in `shared/exception/ErrorConstant`.
+
+## Persistence and Migrations
+- Flyway location: `src/main/resources/migration`.
+- Naming: `V{N}__{description}.sql`.
+- Current authorization-related source tables:
+  - `permissions`, `roles`, `role_permissions`, `user_roles`, `api_permissions`, `policy_version`
+
+## Internal Policy APIs (Contract for Gateway)
+- `GET /v1/internal/policies`
+- `GET /v1/internal/policies/version`
+- Security is configurable mTLS/x509 via `application.security.internal-api.*`.
+
+## Documentation Update Rule
+Update these docs when policy schema or internal API contract changes:
+- `docs/context-map.yaml`
+- `docs/adr/*` (new decision or changed decision)
+
+Use `scripts/check-context-sync.sh` for a lightweight consistency check.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # mangala-authentication
 authentication service for mangala wallet
+
+## Internal Policy API
+
+This service exposes internal APIs used by `mangala-gateway` to load authorization policies:
+
+- `GET /v1/internal/policies`
+- `GET /v1/internal/policies/version`
+
+Details and security model are documented at:
+
+- `docs/internal-policy-api.md`
+
+## Context Pack
+
+Use these files to bootstrap quickly in new sessions:
+
+- `AGENTS.md`
+- `docs/context-map.yaml`
+- `docs/adr/`
+- `scripts/check-context-sync.sh`
+
+Run consistency check:
+
+```bash
+./scripts/check-context-sync.sh
+```

--- a/docs/adr/0001-policy-loading-via-auth-internal-api.md
+++ b/docs/adr/0001-policy-loading-via-auth-internal-api.md
@@ -1,0 +1,25 @@
+# ADR 0001: Policy Loading Via Auth Internal API
+
+## Status
+Accepted
+
+## Context
+`mangala-gateway` enforces authorization but policy data is owned by `mangala-authentication`.
+Direct DB access from gateway into auth schema increases coupling and breaks service boundaries.
+
+## Decision
+Gateway must load policies from auth internal HTTP APIs:
+- `GET /v1/internal/policies`
+- `GET /v1/internal/policies/version`
+
+`/v1/internal/policies/version` is used as a lightweight change detector.
+When remote version is newer, gateway reloads full snapshot from `/v1/internal/policies` and atomically swaps in-memory cache.
+
+## Consequences
+- Pros:
+  - Preserves auth service ownership of policy model.
+  - Reduces coupling to auth DB schema.
+  - Simplifies gateway cache consistency model.
+- Cons:
+  - Requires internal API hardening (service-to-service auth, ideally mTLS).
+  - Requires operational reliability for auth internal endpoints.

--- a/docs/adr/0002-internal-policy-mtls-authorization.md
+++ b/docs/adr/0002-internal-policy-mtls-authorization.md
@@ -1,0 +1,28 @@
+# ADR 0002: Protect Internal Policy APIs With Optional mTLS
+
+## Status
+Accepted
+
+## Context
+`/v1/internal/policies` and `/v1/internal/policies/version` are consumed by gateway and contain authorization policy data.
+Leaving these endpoints open increases risk of policy exfiltration and unauthorized access.
+
+## Decision
+Add dedicated security configuration for `/v1/internal/**`:
+- Support x509 client certificate authentication.
+- Extract client principal from certificate DN using configurable regex.
+- Authorize only configured principal values and grant `INTERNAL_POLICY_READ` authority.
+- Keep `mtls-enabled=false` default for local development compatibility.
+
+Config keys:
+- `application.security.internal-api.mtls-enabled`
+- `application.security.internal-api.subject-principal-regex`
+- `application.security.internal-api.allowed-principals`
+
+## Consequences
+- Pros:
+  - Enforces service identity for internal policy APIs in production.
+  - Reduces risk of unauthorized internal policy reads.
+- Cons:
+  - Requires certificate issuance/rotation and environment TLS setup.
+  - Misconfigured CN allowlist can block gateway bootstrap.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# ADR Guide
+
+Keep Architecture Decision Records concise and immutable.
+
+## File naming
+- `0001-short-title.md`, `0002-short-title.md`, ...
+
+## Template
+```
+# ADR {N}: {Title}
+
+## Status
+Accepted | Proposed | Superseded
+
+## Context
+What problem are we solving? What constraints exist?
+
+## Decision
+What was chosen?
+
+## Consequences
+Tradeoffs, risks, and follow-up actions.
+```
+
+## Rules
+- Do not rewrite history in old ADRs.
+- If a decision changes, add a new ADR that supersedes old one.
+- Link related ADRs explicitly.

--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -1,0 +1,78 @@
+version: 1
+service:
+  name: mangala-authentication
+  package: org.mangala.authentication
+  runtime: spring-boot-3.4.x
+
+entrypoints:
+  main_class: src/main/java/org/mangala/authentication/MainApplication.java
+  web_controllers:
+    - src/main/java/org/mangala/authentication/auth/adapter/web/AuthController.java
+    - src/main/java/org/mangala/authentication/policy/adapter/web/InternalPolicyController.java
+
+architecture:
+  style: feature-first layered
+  layers:
+    - name: adapter_web
+      path_pattern: "*/adapter/web/*"
+      responsibility: transport layer, dto mapping
+    - name: usecase
+      path_pattern: "*/usecase/*"
+      responsibility: application logic orchestration
+    - name: domain
+      path_pattern: "*/domain/*"
+      responsibility: entities and business exceptions
+    - name: adapter_repository
+      path_pattern: "*/adapter/repository/*"
+      responsibility: data access via spring data jpa
+
+naming:
+  java:
+    field_case: camelCase
+    usecase_interface_suffix: UseCase
+    usecase_impl_suffix: UseCaseImpl
+    request_dto_suffix: RequestDTO
+    response_dto_suffix: ResponseDTO
+  database:
+    column_case: snake_case
+    migration_pattern: "V{N}__{description}.sql"
+
+security_and_permissions:
+  source_of_truth_tables:
+    - permissions
+    - roles
+    - role_permissions
+    - user_roles
+    - api_permissions
+    - policy_version
+  internal_contracts_required_by_gateway:
+    - method: GET
+      path: /v1/internal/policies
+      purpose: full active policy snapshot for gateway cache load
+    - method: GET
+      path: /v1/internal/policies/version
+      purpose: lightweight version check for conditional reload
+  internal_policy_security:
+    mode: optional_mtls
+    config_keys:
+      - application.security.internal-api.mtls-enabled
+      - application.security.internal-api.subject-principal-regex
+      - application.security.internal-api.allowed-principals
+    authority: INTERNAL_POLICY_READ
+
+integration:
+  depends_on_modules:
+    - mangala-common-security
+    - mangala-exception
+  gateway_dependency:
+    service: mangala-gateway
+    contract_type: internal_http_api
+
+operational_rules:
+  if_changed_then_update_docs:
+    - src/main/resources/migration/
+    - internal policy api contract
+  required_docs:
+    - AGENTS.md
+    - docs/context-map.yaml
+    - docs/adr/

--- a/docs/internal-policy-api.md
+++ b/docs/internal-policy-api.md
@@ -1,0 +1,90 @@
+# Internal Policy API
+
+## Purpose
+Provide policy snapshot data for `mangala-gateway` authorization cache.
+
+## Endpoints
+- `GET /v1/internal/policies`
+- `GET /v1/internal/policies/version`
+
+## Response Contracts
+### GET /v1/internal/policies
+Returns `List<ApiPermissionDTO>` from `org.mangala.security.model.ApiPermissionDTO`.
+
+Example item:
+```json
+{
+  "id": "f56f7df6-4ee6-4f0f-a3a0-f6f45e90ea6d",
+  "httpMethod": "GET",
+  "pathPattern": "/api/v1/wallets",
+  "permissionCode": "wallets:read",
+  "conditionExpr": null,
+  "serviceName": "wallet-service",
+  "priority": 10,
+  "active": true
+}
+```
+
+### GET /v1/internal/policies/version
+Returns a single JSON number:
+```json
+42
+```
+
+## Data Source
+`GET /v1/internal/policies` query joins:
+- `api_permissions`
+- `permissions`
+
+Filter:
+- `api_permissions.is_active = true`
+- `permissions.is_active = true`
+
+Order:
+- `priority DESC, path_pattern ASC, http_method ASC`
+
+## Security Model
+Security is controlled by:
+- `application.security.internal-api.mtls-enabled`
+- `application.security.internal-api.subject-principal-regex`
+- `application.security.internal-api.allowed-principals`
+
+When `mtls-enabled=true`:
+- `/v1/internal/**` requires x509 client certificate authentication.
+- Extracted principal must be listed in `allowed-principals`.
+- Authorized principal receives `INTERNAL_POLICY_READ` authority to access:
+  - `GET /v1/internal/policies`
+  - `GET /v1/internal/policies/version`
+
+When `mtls-enabled=false`:
+- `/v1/internal/**` is permitted (for local/dev bootstrapping only).
+
+## Sequence
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GW as Gateway (PolicyLoader)
+    participant TLS as mTLS Layer
+    participant AC as Auth InternalPolicyController
+    participant AS as Auth PolicyQueryService
+    participant DB as Auth DB (api_permissions + permissions + policy_version)
+    participant PC as Gateway PolicyCache
+
+    Note over GW,PC: Trigger: Gateway startup or reload by version/event
+
+    GW->>TLS: HTTPS GET /v1/internal/policies
+    TLS->>AC: Validate client cert (gateway identity)
+    AC->>AS: getActivePolicies()
+    AS->>DB: SELECT active policy rules + permission code join
+    DB-->>AS: Policy rows
+    AS-->>AC: List<ApiPermissionDTO>
+    AC-->>GW: 200 OK + JSON policies
+
+    GW->>PC: loadFromDatabase(policies) (atomic swap)
+    PC-->>GW: Cache healthy=true, totalRules updated
+
+    alt Auth unavailable / timeout
+        GW-->>GW: Retry with backoff + circuit breaker
+        GW-->>PC: Keep old cache (if exists), mark degraded if empty
+    end
+```

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
@@ -62,6 +66,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -152,5 +161,35 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>context-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>check-context-sync</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <arguments>
+                                        <argument>${project.basedir}/scripts/check-context-sync.sh</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/scripts/check-context-sync.sh
+++ b/scripts/check-context-sync.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CONTEXT_FILE="docs/context-map.yaml"
+ADR_DIR="docs/adr"
+
+if [[ ! -f "$CONTEXT_FILE" ]]; then
+  echo "[FAIL] Missing $CONTEXT_FILE"
+  exit 1
+fi
+
+if [[ ! -d "$ADR_DIR" ]]; then
+  echo "[FAIL] Missing $ADR_DIR"
+  exit 1
+fi
+
+# Collect changed files including untracked files
+CHANGED_FILES="$(git status --porcelain | awk '{print $2}')"
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo "[OK] No file changes detected."
+  exit 0
+fi
+
+needs_doc_update=0
+
+if echo "$CHANGED_FILES" | grep -q '^src/main/resources/migration/'; then
+  needs_doc_update=1
+fi
+
+if echo "$CHANGED_FILES" | grep -qE '^src/main/java/.*/(adapter/web|usecase|domain|adapter/repository)/'; then
+  if echo "$CHANGED_FILES" | grep -qE 'internal|policy|permission|role'; then
+    needs_doc_update=1
+  fi
+fi
+
+if [[ "$needs_doc_update" -eq 1 ]]; then
+  if ! echo "$CHANGED_FILES" | grep -q '^docs/context-map.yaml'; then
+    echo "[WARN] Policy/schema-related code changed but docs/context-map.yaml was not updated."
+    exit 2
+  fi
+fi
+
+echo "[OK] Context sync check passed."

--- a/src/main/java/org/mangala/authentication/passkey/domain/UserPasskeyEntity.java
+++ b/src/main/java/org/mangala/authentication/passkey/domain/UserPasskeyEntity.java
@@ -62,7 +62,7 @@ public class UserPasskeyEntity {
     private String deviceName;
 
     @Column(name = "device_type", length = 255)
-    private String device_type;
+    private String deviceType;
 
     @Column(name = "attestation_format", length = 50)
     private String attestationFormat;

--- a/src/main/java/org/mangala/authentication/policy/adapter/web/InternalPolicyController.java
+++ b/src/main/java/org/mangala/authentication/policy/adapter/web/InternalPolicyController.java
@@ -1,0 +1,29 @@
+package org.mangala.authentication.policy.adapter.web;
+
+import lombok.RequiredArgsConstructor;
+import org.mangala.authentication.policy.usecase.PolicyQueryService;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(path = "/v1/internal", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class InternalPolicyController {
+
+    private final PolicyQueryService policyQueryService;
+
+    @GetMapping("/policies")
+    public List<ApiPermissionDTO> getPolicies() {
+        return policyQueryService.getActivePolicies();
+    }
+
+    @GetMapping("/policies/version")
+    public long getPolicyVersion() {
+        return policyQueryService.getPolicyVersion();
+    }
+}

--- a/src/main/java/org/mangala/authentication/policy/usecase/PolicyQueryService.java
+++ b/src/main/java/org/mangala/authentication/policy/usecase/PolicyQueryService.java
@@ -1,0 +1,12 @@
+package org.mangala.authentication.policy.usecase;
+
+import org.mangala.security.model.ApiPermissionDTO;
+
+import java.util.List;
+
+public interface PolicyQueryService {
+
+    List<ApiPermissionDTO> getActivePolicies();
+
+    long getPolicyVersion();
+}

--- a/src/main/java/org/mangala/authentication/policy/usecase/PolicyQueryServiceImpl.java
+++ b/src/main/java/org/mangala/authentication/policy/usecase/PolicyQueryServiceImpl.java
@@ -1,0 +1,58 @@
+package org.mangala.authentication.policy.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyQueryServiceImpl implements PolicyQueryService {
+
+    private static final String SELECT_ACTIVE_POLICIES = """
+            SELECT
+                ap.id::text AS id,
+                ap.http_method,
+                ap.path_pattern,
+                p.code AS permission_code,
+                ap.condition_expr,
+                ap.service_name,
+                ap.priority,
+                ap.is_active
+            FROM api_permissions ap
+            INNER JOIN permissions p ON p.id = ap.permission_id
+            WHERE ap.is_active = true
+              AND p.is_active = true
+            ORDER BY ap.priority DESC, ap.path_pattern ASC, ap.http_method ASC
+            """;
+
+    private static final String SELECT_POLICY_VERSION = """
+            SELECT version
+            FROM policy_version
+            WHERE id = 1
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<ApiPermissionDTO> getActivePolicies() {
+        return jdbcTemplate.query(SELECT_ACTIVE_POLICIES, (rs, rowNum) -> ApiPermissionDTO.builder()
+                .id(rs.getString("id"))
+                .httpMethod(rs.getString("http_method"))
+                .pathPattern(rs.getString("path_pattern"))
+                .permissionCode(rs.getString("permission_code"))
+                .conditionExpr(rs.getString("condition_expr"))
+                .serviceName(rs.getString("service_name"))
+                .priority(rs.getInt("priority"))
+                .active(rs.getBoolean("is_active"))
+                .build());
+    }
+
+    @Override
+    public long getPolicyVersion() {
+        Long version = jdbcTemplate.queryForObject(SELECT_POLICY_VERSION, Long.class);
+        return version != null ? version : 1L;
+    }
+}

--- a/src/main/java/org/mangala/authentication/shared/config/security/InternalApiSecurityConfig.java
+++ b/src/main/java/org/mangala/authentication/shared/config/security/InternalApiSecurityConfig.java
@@ -1,0 +1,80 @@
+package org.mangala.authentication.shared.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableConfigurationProperties(InternalApiSecurityProperties.class)
+public class InternalApiSecurityConfig {
+
+    private static final String INTERNAL_POLICY_READ_AUTHORITY = "INTERNAL_POLICY_READ";
+
+    private final InternalApiSecurityProperties securityProperties;
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain internalApiSecurityFilterChain(HttpSecurity http) throws Exception {
+        http.securityMatcher("/v1/internal/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        if (securityProperties.isMtlsEnabled()) {
+            http.x509(x509 -> x509
+                            .subjectPrincipalRegex(securityProperties.getSubjectPrincipalRegex())
+                            .userDetailsService(internalClientUserDetailsService()))
+                    .authorizeHttpRequests(auth -> auth
+                            .requestMatchers(HttpMethod.GET,
+                                    "/v1/internal/policies",
+                                    "/v1/internal/policies/version")
+                            .hasAuthority(INTERNAL_POLICY_READ_AUTHORITY)
+                            .anyRequest().denyAll());
+        } else {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        }
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .anonymous(Customizer.withDefaults())
+                .build();
+    }
+
+    @Bean
+    public UserDetailsService internalClientUserDetailsService() {
+        return principal -> {
+            if (securityProperties.getAllowedPrincipals().contains(principal)) {
+                UserDetails user = User.withUsername(principal)
+                        .password("{noop}n/a")
+                        .authorities(INTERNAL_POLICY_READ_AUTHORITY)
+                        .build();
+                return user;
+            }
+            throw new UsernameNotFoundException("Internal principal is not allowed: " + principal);
+        };
+    }
+}

--- a/src/main/java/org/mangala/authentication/shared/config/security/InternalApiSecurityProperties.java
+++ b/src/main/java/org/mangala/authentication/shared/config/security/InternalApiSecurityProperties.java
@@ -1,0 +1,28 @@
+package org.mangala.authentication.shared.config.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "application.security.internal-api")
+public class InternalApiSecurityProperties {
+
+    /**
+     * Enable mTLS/x509 authentication for /v1/internal/** endpoints.
+     */
+    private boolean mtlsEnabled = false;
+
+    /**
+     * Extract service identity from certificate subject DN.
+     */
+    private String subjectPrincipalRegex = "CN=(.*?)(?:,|$)";
+
+    /**
+     * Allowed internal caller identities (usually certificate CN).
+     */
+    private List<String> allowedPrincipals = List.of("gateway-service");
+}

--- a/src/main/java/org/mangala/authentication/user/domain/UserEntity.java
+++ b/src/main/java/org/mangala/authentication/user/domain/UserEntity.java
@@ -29,7 +29,7 @@ public class UserEntity {
 
     @CreatedBy
     @Column(name = "created_by")
-    private UUID created_by;
+    private UUID createdBy;
 
     @CreatedDate
     @Column(name = "created_at")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,14 @@ application:
         user-verification: ${PASSKEY_AUTHENTICATOR_USER_VERIFICATION:preferred}
       attestation: ${PASSKEY_ATTESTATION:none}
       algorithms: ${PASSKEY_ALGORITHMS}
+  security:
+    internal-api:
+      # Set to true to enforce x509 client-cert authentication on /v1/internal/** APIs
+      mtls-enabled: ${INTERNAL_API_MTLS_ENABLED:false}
+      # Extract service identity from certificate subject DN
+      subject-principal-regex: ${INTERNAL_API_SUBJECT_REGEX:CN=(.*?)(?:,|$)}
+      # Allowed internal caller identities (certificate CN by default)
+      allowed-principals: ${INTERNAL_API_ALLOWED_PRINCIPALS:gateway-service}
 
 
 springdoc:

--- a/src/test/java/org/mangala/authentication/policy/adapter/web/InternalPolicyControllerMtlsDisabledTest.java
+++ b/src/test/java/org/mangala/authentication/policy/adapter/web/InternalPolicyControllerMtlsDisabledTest.java
@@ -1,0 +1,49 @@
+package org.mangala.authentication.policy.adapter.web;
+
+import org.junit.jupiter.api.Test;
+import org.mangala.authentication.shared.config.security.InternalApiSecurityConfig;
+import org.mangala.authentication.policy.usecase.PolicyQueryService;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InternalPolicyController.class)
+@Import(InternalApiSecurityConfig.class)
+@TestPropertySource(properties = {
+        "application.security.internal-api.mtls-enabled=false"
+})
+class InternalPolicyControllerMtlsDisabledTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private PolicyQueryService policyQueryService;
+
+    @Test
+    void shouldAllowRequestWithoutClientCertificateWhenMtlsDisabled() throws Exception {
+        ApiPermissionDTO policy = ApiPermissionDTO.builder()
+                .id("rule-1")
+                .httpMethod("GET")
+                .pathPattern("/api/v1/wallets")
+                .permissionCode("wallets:read")
+                .priority(10)
+                .active(true)
+                .build();
+        when(policyQueryService.getActivePolicies()).thenReturn(List.of(policy));
+
+        mockMvc.perform(get("/v1/internal/policies"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].permissionCode").value("wallets:read"));
+    }
+}

--- a/src/test/java/org/mangala/authentication/policy/adapter/web/InternalPolicyControllerMtlsEnabledTest.java
+++ b/src/test/java/org/mangala/authentication/policy/adapter/web/InternalPolicyControllerMtlsEnabledTest.java
@@ -1,0 +1,79 @@
+package org.mangala.authentication.policy.adapter.web;
+
+import org.junit.jupiter.api.Test;
+import org.mangala.authentication.shared.config.security.InternalApiSecurityConfig;
+import org.mangala.authentication.policy.usecase.PolicyQueryService;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.x509;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InternalPolicyController.class)
+@Import(InternalApiSecurityConfig.class)
+@TestPropertySource(properties = {
+        "application.security.internal-api.mtls-enabled=true",
+        "application.security.internal-api.allowed-principals=gateway-service"
+})
+class InternalPolicyControllerMtlsEnabledTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private PolicyQueryService policyQueryService;
+
+    @Test
+    void shouldRejectRequestWithoutClientCertificateWhenMtlsEnabled() throws Exception {
+        mockMvc.perform(get("/v1/internal/policies"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowRequestWithTrustedClientCertificateWhenMtlsEnabled() throws Exception {
+        ApiPermissionDTO policy = ApiPermissionDTO.builder()
+                .id("rule-1")
+                .httpMethod("GET")
+                .pathPattern("/api/v1/wallets")
+                .permissionCode("wallets:read")
+                .priority(10)
+                .active(true)
+                .build();
+        when(policyQueryService.getActivePolicies()).thenReturn(List.of(policy));
+
+        X509Certificate certificate = mock(X509Certificate.class);
+        X500Principal principal = new X500Principal("CN=gateway-service,OU=Platform");
+        when(certificate.getSubjectX500Principal()).thenReturn(principal);
+        when(certificate.getSubjectDN()).thenReturn(principal);
+
+        mockMvc.perform(get("/v1/internal/policies").with(x509(certificate)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].permissionCode").value("wallets:read"));
+    }
+
+    @Test
+    void shouldReturnPolicyVersionForTrustedClientCertificate() throws Exception {
+        when(policyQueryService.getPolicyVersion()).thenReturn(99L);
+
+        X509Certificate certificate = mock(X509Certificate.class);
+        X500Principal principal = new X500Principal("CN=gateway-service,OU=Platform");
+        when(certificate.getSubjectX500Principal()).thenReturn(principal);
+        when(certificate.getSubjectDN()).thenReturn(principal);
+
+        mockMvc.perform(get("/v1/internal/policies/version").with(x509(certificate)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(99));
+    }
+}

--- a/src/test/java/org/mangala/authentication/policy/usecase/PolicyQueryServiceImplTest.java
+++ b/src/test/java/org/mangala/authentication/policy/usecase/PolicyQueryServiceImplTest.java
@@ -1,0 +1,73 @@
+package org.mangala.authentication.policy.usecase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mangala.security.model.ApiPermissionDTO;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PolicyQueryServiceImplTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private PolicyQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PolicyQueryServiceImpl(jdbcTemplate);
+    }
+
+    @Test
+    void shouldReturnActivePoliciesFromDatabase() {
+        ApiPermissionDTO row = ApiPermissionDTO.builder()
+                .id("policy-1")
+                .httpMethod("GET")
+                .pathPattern("/api/v1/wallets")
+                .permissionCode("wallets:read")
+                .conditionExpr(null)
+                .serviceName("wallet-service")
+                .priority(10)
+                .active(true)
+                .build();
+
+        when(jdbcTemplate.query(anyString(), any(org.springframework.jdbc.core.RowMapper.class)))
+                .thenReturn(List.of(row));
+
+        List<ApiPermissionDTO> result = service.getActivePolicies();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getPermissionCode()).isEqualTo("wallets:read");
+        assertThat(result.getFirst().isActive()).isTrue();
+    }
+
+    @Test
+    void shouldReturnVersionFromDatabase() {
+        when(jdbcTemplate.queryForObject(anyString(), org.mockito.ArgumentMatchers.eq(Long.class)))
+                .thenReturn(42L);
+
+        long version = service.getPolicyVersion();
+
+        assertThat(version).isEqualTo(42L);
+    }
+
+    @Test
+    void shouldFallbackToVersionOneWhenDbReturnsNull() {
+        when(jdbcTemplate.queryForObject(anyString(), org.mockito.ArgumentMatchers.eq(Long.class)))
+                .thenReturn(null);
+
+        long version = service.getPolicyVersion();
+
+        assertThat(version).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
Summary
This PR delivers two main outcomes:

Adds versioned internal policy APIs in mangala-authentication for gateway policy loading:
GET /v1/internal/policies
GET /v1/internal/policies/version
Establishes repository knowledge base/context artifacts for faster future Codex sessions and safer architecture changes:
[AGENTS.md](app://-/index.html#)
[context-map.yaml](app://-/index.html#)
ADRs under docs/adr/
context consistency script + CI + Maven profile
Why
Gateway needs stable internal APIs to load policy snapshot and version for cache synchronization.
Service boundaries should be preserved (gateway loads policy via auth API, not direct DB access).
Codex/new sessions were repeatedly re-learning architecture by scanning code; this adds a durable context pack.
Internal API security config was refactored into global shared config to avoid feature-level coupling.
What changed
Internal policy API
Added controller:
GET /v1/internal/policies
GET /v1/internal/policies/version
Added policy query service + DB queries:
fetch active policy rows from api_permissions + permissions
fetch current policy_version
Security (globalized)
Introduced global internal API security config in shared/config/security:
InternalApiSecurityConfig
InternalApiSecurityProperties
Security applies to /v1/internal/**.
Optional x509/mTLS application-layer authz via:
application.security.internal-api.mtls-enabled
application.security.internal-api.subject-principal-regex
application.security.internal-api.allowed-principals
Authorized principals receive INTERNAL_POLICY_READ authority for policy endpoints.
Removed legacy/unversioned internal endpoints
Removed compatibility mapping for /internal/policies and /internal/policies/version.
Versioned contract is now the only supported path.
Gateway alignment
Updated gateway policy loader calls to:
/v1/internal/policies
/v1/internal/policies/version
Knowledge base / docs / governance
Added/updated:
[AGENTS.md](app://-/index.html#)
[context-map.yaml](app://-/index.html#)
[internal-policy-api.md](app://-/index.html#) (includes sequence diagram)
[0001-policy-loading-via-auth-internal-api.md](app://-/index.html#)
[0002-internal-policy-mtls-authorization.md](app://-/index.html#)
[README.md](app://-/index.html#)
Added guardrail script:
[check-context-sync.sh](app://-/index.html#)
Added CI workflow:
[context-sync.yml](app://-/index.html#)
Added Maven profile:
-Pcontext-check to run context sync check.
Testing
Added unit tests for policy query service.
Added web/security tests for internal policy endpoints:
mTLS enabled path behavior
mTLS disabled path behavior
Executed:
mvn test
[check-context-sync.sh](app://-/index.html#)
mvn -Pcontext-check validate
Notes for deployment
To enforce internal API x509 checks at app layer, set:
INTERNAL_API_MTLS_ENABLED=true
For full transport-layer mTLS, also configure server SSL client-auth and trust/key stores in environment (outside this PR’s core code path).