### PR TITLE
fix(auth-passkey): persist registration identity consistently and fix authenticate challenge encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mangala</groupId>
             <artifactId>common-security</artifactId>
         </dependency>

--- a/src/main/java/org/mangala/authentication/auth/adapter/web/dto/PasskeyRegistrationOptionsDTO.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/web/dto/PasskeyRegistrationOptionsDTO.java
@@ -10,6 +10,8 @@ import java.util.List;
 @Builder
 public class PasskeyRegistrationOptionsDTO {
 
+    private String sessionId;
+
     private RelyingPartyDTO rp;
     private UserDTO user;
 

--- a/src/main/java/org/mangala/authentication/auth/adapter/web/mapper/PasskeyResponseMapper.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/web/mapper/PasskeyResponseMapper.java
@@ -34,6 +34,7 @@ public final class PasskeyResponseMapper {
         }
 
         return PasskeyRegistrationOptionsDTO.builder()
+                .sessionId(response.getSessionId())
                 .rp(toRelyingPartyDTO(response.getRp()))
                 .user(toUserDTO(response.getUser()))
                 .challenge(encodeBase64Url(response.getChallenge()))

--- a/src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java
@@ -75,7 +75,7 @@ public class CompleteAuthenticationUseCaseImpl implements CompleteAuthentication
                 signature,
                 userHandle,
                 passkey.getPublicKey(),
-                new String(challenge.getChallenge()),
+                Base64UrlUtil.encodeToString(challenge.getChallenge()),
                 webAuthnConfig.getRp().getId(),
                 webAuthnConfig.getRp().getOrigin(),
                 true // require user verification

--- a/src/main/java/org/mangala/authentication/auth/usecase/CompleteRegistrationUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/CompleteRegistrationUseCaseImpl.java
@@ -13,13 +13,10 @@ import org.mangala.authentication.passkey.usecase.command.VerifyRegistrationCred
 import org.mangala.authentication.user.adapter.repository.UserRepository;
 import org.mangala.authentication.user.domain.UserEntity;
 import org.mangala.authentication.user.domain.UserNotFoundException;
-import org.mangala.authentication.user.usecase.CreateUserUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -32,7 +29,6 @@ public class CompleteRegistrationUseCaseImpl implements CompleteRegistrationUseC
     private final CheckDuplicateCredentialUseCase checkDuplicateCredentialUseCase;
     private final SavePasskeyUseCase savePasskeyUseCase;
     private final MarkChallengeAsUsedUseCase markChallengeAsUsedUseCase;
-    private final CreateUserUseCase createUserUseCase;
     private final UserRepository userRepository;
 
     @Override
@@ -110,16 +106,13 @@ public class CompleteRegistrationUseCaseImpl implements CompleteRegistrationUseC
     }
 
     private UserEntity getUserForChallenge(PasskeyChallengeEntity challenge) {
-        if (challenge.getUserId() != null) {
-            // User was created during start registration (with email)
-            return userRepository.findById(challenge.getUserId())
-                .orElseThrow(UserNotFoundException::new);
-        } else {
-            // Create anonymous user with the user ID from the challenge
-            // The user ID was generated during start registration and sent to client
-            // We need to extract it somehow, but for now, create a new user
-            return createUserUseCase.execute(null, null);
+        if (challenge.getUserId() == null) {
+            log.error("Registration challenge {} has no userId", challenge.getSessionId());
+            throw new UserNotFoundException();
         }
+
+        return userRepository.findById(challenge.getUserId())
+            .orElseThrow(UserNotFoundException::new);
     }
 
     private String extractDeviceName(String userAgent) {

--- a/src/main/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseImpl.java
@@ -10,13 +10,13 @@ import org.mangala.authentication.passkey.usecase.command.CreatePasskeyChallenge
 import org.mangala.authentication.shared.config.WebAuthnConfigProperties;
 import org.mangala.authentication.user.domain.UserWithEmailExistedException;
 import org.mangala.authentication.user.usecase.CheckUserExistedUseCase;
+import org.mangala.authentication.user.usecase.CreateUserUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -27,35 +27,39 @@ public class StartRegistrationUseCaseImpl implements StartRegistrationUseCase {
 
     private final WebAuthnConfigProperties webAuthnConfigProperties;
     private final CheckUserExistedUseCase checkUserExistedUseCase;
+    private final CreateUserUseCase createUserUseCase;
     private final CreatePasskeyChallengeUseCase createPasskeyChallengeUseCase;
 
     @Override
     public StartRegisterPasskeyResponse execute(String email, String ipAddress, String userAgent) {
         final var sessionId = UUID.randomUUID().toString();
         final var challenge = new DefaultChallenge().getValue();
+        final var normalizedEmail = normalizeEmail(email);
         final var rp = new PublicKeyCredentialRpEntity(
                 webAuthnConfigProperties.getRp().getId(),
                 webAuthnConfigProperties.getRp().getName()
         );
         String username;
         String userDisplayName;
-        if (Objects.nonNull(email)) {
-            if (checkUserExistedUseCase.execute(email)) {
+        if (Objects.nonNull(normalizedEmail)) {
+            if (checkUserExistedUseCase.execute(normalizedEmail)) {
                 throw new UserWithEmailExistedException();
             }
-            username = email;
-            userDisplayName = email;
+            username = normalizedEmail;
+            userDisplayName = normalizedEmail;
         } else {
             username = UUID.randomUUID().toString();
             userDisplayName = username;
         }
+
+        final var persistedUser = createUserUseCase.execute(normalizedEmail, null);
         final var userEntity = new PublicKeyCredentialUserEntity(
-                UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8),
+                persistedUser.getId().toString().getBytes(StandardCharsets.UTF_8),
                 username,
                 userDisplayName
         );
 
-        createPasskeyChallenge(challenge, sessionId, ipAddress, userAgent);
+        createPasskeyChallenge(challenge, sessionId, ipAddress, userAgent, persistedUser.getId());
 
         AuthenticatorSelectionCriteria authenticatorSelection =
                 new AuthenticatorSelectionCriteria(
@@ -65,6 +69,7 @@ public class StartRegistrationUseCaseImpl implements StartRegistrationUseCase {
                 );
 
         return StartRegisterPasskeyResponse.builder()
+                .sessionId(sessionId)
                 .rp(rp)
                 .user(userEntity)
                 .challenge(challenge)
@@ -76,18 +81,33 @@ public class StartRegistrationUseCaseImpl implements StartRegistrationUseCase {
                 .build();
     }
 
-    private void createPasskeyChallenge(byte[] challenge, String session, String ipAddress, String userAgent) {
+    private void createPasskeyChallenge(
+            byte[] challenge,
+            String session,
+            String ipAddress,
+            String userAgent,
+            UUID userId
+    ) {
         final var expiresAt = LocalDateTime.now().plusSeconds(webAuthnConfigProperties.getTimeout());
         var createPasskeyChallengeCommand = CreatePasskeyChallengeCommand
                 .builder()
                 .operationType(PasskeyChallengeOperationType.REGISTER)
                 .sessionId(session)
                 .challenge(challenge)
+                .userId(userId.toString())
                 .ipAddress(ipAddress)
                 .userAgent(userAgent)
                 .expiresAt(expiresAt)
                 .userVerificationRequirement(webAuthnConfigProperties.getAuthenticator().getUserVerification())
                 .build();
         createPasskeyChallengeUseCase.execute(createPasskeyChallengeCommand);
+    }
+
+    private String normalizeEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+        String trimmed = email.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/org/mangala/authentication/auth/usecase/model/StartRegisterPasskeyResponse.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/model/StartRegisterPasskeyResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Builder
 @Data
 public class StartRegisterPasskeyResponse {
+    private String sessionId;
     private PublicKeyCredentialRpEntity rp;
     private PublicKeyCredentialUserEntity user;
     private byte[] challenge;

--- a/src/test/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseImplTest.java
+++ b/src/test/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseImplTest.java
@@ -1,0 +1,122 @@
+package org.mangala.authentication.auth.usecase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mangala.authentication.passkey.domain.PasskeyChallengeOperationType;
+import org.mangala.authentication.passkey.domain.PasskeyChallengeEntity;
+import org.mangala.authentication.passkey.usecase.CreatePasskeyChallengeUseCase;
+import org.mangala.authentication.passkey.usecase.command.CreatePasskeyChallengeCommand;
+import org.mangala.authentication.shared.config.WebAuthnConfigProperties;
+import org.mangala.authentication.user.domain.UserEntity;
+import org.mangala.authentication.user.usecase.CheckUserExistedUseCase;
+import org.mangala.authentication.user.usecase.CreateUserUseCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class StartRegistrationUseCaseImplTest {
+
+    private FakeCheckUserExistedUseCase checkUserExistedUseCase;
+    private FakeCreateUserUseCase createUserUseCase;
+    private FakeCreatePasskeyChallengeUseCase createPasskeyChallengeUseCase;
+    private WebAuthnConfigProperties webAuthnConfigProperties;
+    private StartRegistrationUseCaseImpl startRegistrationUseCase;
+
+    @BeforeEach
+    void setUp() {
+        checkUserExistedUseCase = new FakeCheckUserExistedUseCase(false);
+        createUserUseCase = new FakeCreateUserUseCase();
+        createPasskeyChallengeUseCase = new FakeCreatePasskeyChallengeUseCase();
+
+        webAuthnConfigProperties = new WebAuthnConfigProperties();
+
+        WebAuthnConfigProperties.RelyingParty rp = new WebAuthnConfigProperties.RelyingParty();
+        rp.setId("localhost");
+        rp.setName("localhost");
+
+        WebAuthnConfigProperties.Authenticator authenticator = new WebAuthnConfigProperties.Authenticator();
+        authenticator.setUserVerification("preferred");
+
+        webAuthnConfigProperties.setRp(rp);
+        webAuthnConfigProperties.setTimeout(300000L);
+        webAuthnConfigProperties.setAuthenticator(authenticator);
+
+        startRegistrationUseCase = new StartRegistrationUseCaseImpl(
+            webAuthnConfigProperties,
+            checkUserExistedUseCase,
+            createUserUseCase,
+            createPasskeyChallengeUseCase
+        );
+    }
+
+    @Test
+    void execute_shouldCreateUserAndPersistChallengeWithSameUserId() {
+        String email = "dat@gmail.com";
+
+        var response = startRegistrationUseCase.execute(email, "127.0.0.1", "JUnit");
+
+        assertNotNull(response);
+        assertEquals(email, response.getUser().getName());
+        assertEquals(email, response.getUser().getDisplayName());
+        assertTrue(createUserUseCase.called);
+        assertEquals(email, createUserUseCase.capturedEmail);
+        assertNull(createUserUseCase.capturedUserId);
+        assertEquals(
+            createUserUseCase.persistedUserId.toString(),
+            new String(response.getUser().getId(), StandardCharsets.UTF_8)
+        );
+
+        assertNotNull(createPasskeyChallengeUseCase.capturedCommand);
+        CreatePasskeyChallengeCommand challengeCommand = createPasskeyChallengeUseCase.capturedCommand;
+        assertEquals(PasskeyChallengeOperationType.REGISTER, challengeCommand.getOperationType());
+        assertEquals(createUserUseCase.persistedUserId.toString(), challengeCommand.getUserId());
+    }
+
+    private static class FakeCheckUserExistedUseCase implements CheckUserExistedUseCase {
+        private final boolean existed;
+
+        private FakeCheckUserExistedUseCase(boolean existed) {
+            this.existed = existed;
+        }
+
+        @Override
+        public boolean execute(String email) {
+            return existed;
+        }
+    }
+
+    private static class FakeCreateUserUseCase implements CreateUserUseCase {
+        private boolean called;
+        private String capturedEmail;
+        private UUID capturedUserId;
+        private UUID persistedUserId;
+
+        @Override
+        public UserEntity execute(String email, UUID userId) {
+            called = true;
+            capturedEmail = email;
+            capturedUserId = userId;
+            persistedUserId = UUID.randomUUID();
+
+            UserEntity userEntity = new UserEntity();
+            userEntity.setId(persistedUserId);
+            userEntity.setEmail(email);
+            return userEntity;
+        }
+    }
+
+    private static class FakeCreatePasskeyChallengeUseCase implements CreatePasskeyChallengeUseCase {
+        private CreatePasskeyChallengeCommand capturedCommand;
+
+        @Override
+        public PasskeyChallengeEntity execute(CreatePasskeyChallengeCommand command) {
+            capturedCommand = command;
+            return new PasskeyChallengeEntity();
+        }
+    }
+}

--- a/src/test/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseIntegrationTest.java
+++ b/src/test/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseIntegrationTest.java
@@ -1,0 +1,84 @@
+package org.mangala.authentication.auth.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.mangala.authentication.passkey.adapter.repository.PasskeyChallengeRepository;
+import org.mangala.authentication.passkey.domain.PasskeyChallengeOperationType;
+import org.mangala.authentication.user.adapter.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Testcontainers
+@SpringBootTest
+class StartRegistrationUseCaseIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+        .withDatabaseName("mangala_auth_test")
+        .withUsername("test")
+        .withPassword("test");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> postgres.getJdbcUrl() + "&currentSchema=auth");
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add("spring.flyway.schemas", () -> "auth");
+        registry.add("spring.flyway.default-schema", () -> "auth");
+
+        registry.add("application.authentication.passkey.rp.id", () -> "localhost");
+        registry.add("application.authentication.passkey.rp.name", () -> "localhost");
+        registry.add("application.authentication.passkey.rp.origin", () -> "http://localhost:5173");
+        registry.add("application.authentication.passkey.timeout", () -> 300000L);
+        registry.add("application.authentication.passkey.algorithms", () -> "ES256,RS256");
+        registry.add("application.authentication.passkey.authenticator.attachment", () -> "platform");
+        registry.add("application.authentication.passkey.authenticator.resident-key", () -> true);
+        registry.add("application.authentication.passkey.authenticator.user-verification", () -> "preferred");
+        registry.add("application.authentication.passkey.attestation", () -> "none");
+    }
+
+    @Autowired
+    private StartRegistrationUseCase startRegistrationUseCase;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasskeyChallengeRepository passkeyChallengeRepository;
+
+    @Test
+    void execute_shouldPersistUserAndChallengeWithConsistentUserId() {
+        String email = "integration-test@gmail.com";
+
+        var response = startRegistrationUseCase.execute(email, "127.0.0.1", "integration-test-agent");
+
+        assertNotNull(response);
+        assertNotNull(response.getSessionId());
+        assertNotNull(response.getUser());
+
+        UUID userIdFromResponse = UUID.fromString(
+            new String(response.getUser().getId(), StandardCharsets.UTF_8)
+        );
+
+        var savedUser = userRepository.findById(userIdFromResponse).orElseThrow();
+        assertEquals(email, savedUser.getEmail());
+
+        var savedChallenge = passkeyChallengeRepository.findBySessionId(response.getSessionId()).orElseThrow();
+        assertEquals(userIdFromResponse, savedChallenge.getUserId());
+        assertEquals(PasskeyChallengeOperationType.REGISTER, savedChallenge.getOperationType());
+        assertFalse(savedChallenge.getIsUsed());
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes critical passkey auth flow issues in `mangala-authentication`:

1. Registration now persists user identity consistently from `passkeys:start` to `passkeys:complete`.
2. Authentication complete now verifies assertions with correctly encoded challenge data.
3. Added Testcontainers-based integration coverage for registration persistence consistency.

## Problems Fixed

### 1) Login failed after successful registration (`User not found`)
- Root cause:
  - Registration challenge did not persist `userId`.
  - `passkeys:complete` could create anonymous user (`email = null`), causing later sign-in-by-email lookup to fail.
- Fix:
  - Create user during `passkeys:start`.
  - Persist that user’s `userId` into challenge.
  - In `passkeys:complete`, require challenge `userId` and resolve exact user (no anonymous fallback).

### 2) `authenticate:complete` failed with assertion verification error (`0000012`)
- Root cause:
  - Expected challenge was passed as `new String(byte[])` instead of Base64URL.
  - Verification attempted Base64URL decode and failed (`Illegal base64 character 3f`).
- Fix:
  - Encode expected challenge with `Base64UrlUtil.encodeToString(challengeBytes)` before verification.

## Test Coverage

### Added
- `StartRegistrationUseCaseIntegrationTest` (Testcontainers + PostgreSQL)
  - Verifies:
    - user row is created during registration start
    - challenge row is created with the same `user_id`
    - challenge operation type is `REGISTER` and `isUsed=false`

### Updated
- `StartRegistrationUseCaseImplTest`
  - Reflects new behavior: persisted user ID is generated by DB flow and then reused in challenge.

## Files Changed (key)
- `src/main/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseImpl.java`
- `src/main/java/org/mangala/authentication/auth/usecase/CompleteRegistrationUseCaseImpl.java`
- `src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java`
- `src/test/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseImplTest.java`
- `src/test/java/org/mangala/authentication/auth/usecase/StartRegistrationUseCaseIntegrationTest.java`
- `pom.xml` (add Testcontainers test dependencies)

## Validation
- `mvn -q -DskipTests compile` ✅
- `mvn -q -Dtest=StartRegistrationUseCaseImplTest test` ✅
- `mvn -q -Dtest=StartRegistrationUseCaseIntegrationTest test` ✅ (requires Docker)

## Notes
- Existing previously-registered anonymous users (created before this fix) may still fail email-based sign-in.
- Please register a new account after deploying this change for clean verification.