### PR TITLE
[MVP] Replace placeholder token generation with production-ready JWT issuance

### DIFF
--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -45,6 +45,44 @@ security_and_permissions:
     - user_roles
     - api_permissions
     - policy_version
+  token_tables:
+    - refresh_tokens
+  external_auth_contracts:
+    - method: POST
+      path: /v1/authenticate/passkeys:complete
+      purpose: verify passkey assertion and issue signed access/refresh JWT tokens
+    - method: POST
+      path: /v1/auth/refresh
+      purpose: rotate refresh token and return a new access/refresh token pair
+  jwt_contract:
+    access_token_claims:
+      - iss
+      - sub
+      - aud
+      - iat
+      - exp
+      - jti
+      - type
+      - email
+      - roles
+      - permissions
+      - amr
+    refresh_token_claims:
+      - iss
+      - sub
+      - aud
+      - iat
+      - exp
+      - jti
+      - type
+      - email
+    config_keys:
+      - application.authentication.jwt.secret
+      - application.authentication.jwt.issuer
+      - application.authentication.jwt.access-token-audience
+      - application.authentication.jwt.refresh-token-audience
+      - application.authentication.jwt.access-token-expiration-seconds
+      - application.authentication.jwt.refresh-token-expiration-seconds
   internal_contracts_required_by_gateway:
     - method: GET
       path: /v1/internal/policies

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,23 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.4</version>
         </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/sample.env
+++ b/sample.env
@@ -5,6 +5,13 @@ DB_SCHEMA=auth
 DB_USERNAME=dev
 DB_PASSWORD=dev123
 
+JWT_SECRET=your-256-bit-secret-key-for-jwt-signing-replace-in-production
+JWT_ISSUER=mangala
+JWT_ACCESS_EXPIRATION_SECONDS=900
+JWT_REFRESH_EXPIRATION_SECONDS=604800
+JWT_ACCESS_AUDIENCE=mangala-gateway
+JWT_REFRESH_AUDIENCE=mangala-auth-refresh
+
 RP_ID=localhost:8080
 RP_ORIGIN=
 RP_NAME=localhost

--- a/src/main/java/org/mangala/authentication/auth/adapter/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package org.mangala.authentication.auth.adapter.repository;
+
+import org.mangala.authentication.auth.domain.RefreshTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+
+    Optional<RefreshTokenEntity> findByTokenId(String tokenId);
+}

--- a/src/main/java/org/mangala/authentication/auth/adapter/repository/UserAuthorizationQueryRepository.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/repository/UserAuthorizationQueryRepository.java
@@ -1,0 +1,52 @@
+package org.mangala.authentication.auth.adapter.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class UserAuthorizationQueryRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public List<String> findRolesByUserId(UUID userId) {
+        String sql = """
+                SELECT r.code
+                FROM user_roles ur
+                JOIN roles r ON r.id = ur.role_id
+                WHERE ur.user_id = :userId
+                  AND r.is_active = true
+                """;
+        return jdbcTemplate.queryForList(sql, new MapSqlParameterSource("userId", userId), String.class);
+    }
+
+    public List<String> findPermissionsByUserId(UUID userId) {
+        String sql = """
+                SELECT DISTINCT p.code
+                FROM user_roles ur
+                JOIN roles r ON r.id = ur.role_id
+                JOIN role_permissions rp ON rp.role_id = r.id
+                JOIN permissions p ON p.id = rp.permission_id
+                WHERE ur.user_id = :userId
+                  AND r.is_active = true
+                  AND p.is_active = true
+                """;
+        return jdbcTemplate.queryForList(sql, new MapSqlParameterSource("userId", userId), String.class);
+    }
+
+    public void assignDefaultRole(UUID userId) {
+        String sql = """
+                INSERT INTO user_roles (user_id, role_id, created_by)
+                SELECT :userId, r.id, 'system'
+                FROM roles r
+                WHERE r.code = 'ROLE_USER'
+                ON CONFLICT (user_id, role_id) DO NOTHING
+                """;
+        jdbcTemplate.update(sql, new MapSqlParameterSource("userId", userId));
+    }
+}

--- a/src/main/java/org/mangala/authentication/auth/adapter/web/AuthController.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/web/AuthController.java
@@ -10,6 +10,7 @@ import org.mangala.authentication.auth.adapter.web.mapper.PasskeyResponseMapper;
 import org.mangala.authentication.auth.usecase.*;
 import org.mangala.authentication.auth.usecase.command.CompleteAuthenticationCommand;
 import org.mangala.authentication.auth.usecase.command.CompletePasskeyRegistrationCommand;
+import org.mangala.authentication.auth.usecase.command.RefreshTokenCommand;
 import org.mangala.authentication.auth.usecase.command.StartAuthenticationCommand;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,7 @@ public class AuthController {
     private final CompleteRegistrationUseCase completeRegistrationUseCase;
     private final StartAuthenticationUseCase startAuthenticationUseCase;
     private final CompleteAuthenticationUseCase completeAuthenticationUseCase;
+    private final RefreshTokenUseCase refreshTokenUseCase;
     private final AuthenticationResponseMapper authenticationResponseMapper;
 
     @PostMapping("/v1/register/passkeys:start")
@@ -117,6 +119,15 @@ public class AuthController {
         );
 
         var response = completeAuthenticationUseCase.execute(command);
+        return authenticationResponseMapper.toCompletePasskeyAuthenticationResponseDTO(response);
+    }
+
+    @PostMapping("/v1/auth/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    public CompletePasskeyAuthenticationResponseDTO refreshToken(
+            @Valid @RequestBody RefreshTokenRequestDTO requestDTO
+    ) {
+        var response = refreshTokenUseCase.execute(new RefreshTokenCommand(requestDTO.refreshToken()));
         return authenticationResponseMapper.toCompletePasskeyAuthenticationResponseDTO(response);
     }
 }

--- a/src/main/java/org/mangala/authentication/auth/adapter/web/dto/RefreshTokenRequestDTO.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/web/dto/RefreshTokenRequestDTO.java
@@ -1,0 +1,6 @@
+package org.mangala.authentication.auth.adapter.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequestDTO(@NotBlank String refreshToken) {
+}

--- a/src/main/java/org/mangala/authentication/auth/domain/InvalidTokenException.java
+++ b/src/main/java/org/mangala/authentication/auth/domain/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package org.mangala.authentication.auth.domain;
+
+import org.mangala.authentication.shared.exception.ErrorConstant;
+import org.mangala.exception.BaseException;
+
+public class InvalidTokenException extends BaseException {
+
+    public InvalidTokenException() {
+        super(ErrorConstant.TOKEN_INVALID);
+    }
+}

--- a/src/main/java/org/mangala/authentication/auth/domain/RefreshTokenEntity.java
+++ b/src/main/java/org/mangala/authentication/auth/domain/RefreshTokenEntity.java
@@ -1,0 +1,35 @@
+package org.mangala.authentication.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@Setter
+public class RefreshTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "token_id", nullable = false, unique = true)
+    private String tokenId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/mangala/authentication/auth/domain/RefreshTokenNotFoundException.java
+++ b/src/main/java/org/mangala/authentication/auth/domain/RefreshTokenNotFoundException.java
@@ -1,0 +1,11 @@
+package org.mangala.authentication.auth.domain;
+
+import org.mangala.authentication.shared.exception.ErrorConstant;
+import org.mangala.exception.BaseException;
+
+public class RefreshTokenNotFoundException extends BaseException {
+
+    public RefreshTokenNotFoundException() {
+        super(ErrorConstant.REFRESH_TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/mangala/authentication/auth/domain/RefreshTokenRevokedException.java
+++ b/src/main/java/org/mangala/authentication/auth/domain/RefreshTokenRevokedException.java
@@ -1,0 +1,11 @@
+package org.mangala.authentication.auth.domain;
+
+import org.mangala.authentication.shared.exception.ErrorConstant;
+import org.mangala.exception.BaseException;
+
+public class RefreshTokenRevokedException extends BaseException {
+
+    public RefreshTokenRevokedException() {
+        super(ErrorConstant.REFRESH_TOKEN_REVOKED);
+    }
+}

--- a/src/main/java/org/mangala/authentication/auth/token/JwtTokenBundle.java
+++ b/src/main/java/org/mangala/authentication/auth/token/JwtTokenBundle.java
@@ -1,0 +1,12 @@
+package org.mangala.authentication.auth.token;
+
+import java.time.Instant;
+
+public record JwtTokenBundle(
+        String accessToken,
+        String refreshToken,
+        String refreshTokenId,
+        long accessExpiresInSeconds,
+        Instant refreshExpiresAt
+) {
+}

--- a/src/main/java/org/mangala/authentication/auth/token/JwtTokenService.java
+++ b/src/main/java/org/mangala/authentication/auth/token/JwtTokenService.java
@@ -1,0 +1,137 @@
+package org.mangala.authentication.auth.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.mangala.authentication.auth.domain.InvalidTokenException;
+import org.mangala.authentication.shared.config.security.JwtProperties;
+import org.mangala.security.SecurityConstants;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private static final String CLAIM_AUTH_METHODS = "amr";
+
+    private final JwtProperties jwtProperties;
+
+    public JwtTokenBundle issueTokenPair(UUID userId, String email, Collection<String> roles, Collection<String> permissions) {
+        Instant now = Instant.now();
+        Instant accessExpiry = now.plusSeconds(jwtProperties.getAccessTokenExpirationSeconds());
+        Instant refreshExpiry = now.plusSeconds(jwtProperties.getRefreshTokenExpirationSeconds());
+
+        String accessJti = UUID.randomUUID().toString();
+        String refreshJti = UUID.randomUUID().toString();
+
+        Map<String, Object> accessClaims = new HashMap<>();
+        if (email != null) {
+            accessClaims.put(SecurityConstants.CLAIM_EMAIL, email);
+        }
+        accessClaims.put(SecurityConstants.CLAIM_ROLES, new ArrayList<>(roles));
+        accessClaims.put(SecurityConstants.CLAIM_PERMISSIONS, new ArrayList<>(permissions));
+        accessClaims.put(SecurityConstants.CLAIM_TOKEN_TYPE, SecurityConstants.TOKEN_TYPE_ACCESS);
+        accessClaims.put(CLAIM_AUTH_METHODS, List.of("passkey"));
+
+        String accessToken = buildToken(
+                userId,
+                jwtProperties.getAccessTokenAudience(),
+                accessJti,
+                now,
+                accessExpiry,
+                accessClaims
+        );
+
+        Map<String, Object> refreshClaims = new HashMap<>();
+        if (email != null) {
+            refreshClaims.put(SecurityConstants.CLAIM_EMAIL, email);
+        }
+        refreshClaims.put(SecurityConstants.CLAIM_TOKEN_TYPE, SecurityConstants.TOKEN_TYPE_REFRESH);
+
+        String refreshToken = buildToken(
+                userId,
+                jwtProperties.getRefreshTokenAudience(),
+                refreshJti,
+                now,
+                refreshExpiry,
+                refreshClaims
+        );
+
+        return new JwtTokenBundle(
+                accessToken,
+                refreshToken,
+                refreshJti,
+                jwtProperties.getAccessTokenExpirationSeconds(),
+                refreshExpiry
+        );
+    }
+
+    public RefreshTokenClaims parseAndValidateRefreshToken(String refreshToken) {
+        Claims claims = parseClaims(refreshToken);
+
+        String tokenType = claims.get(SecurityConstants.CLAIM_TOKEN_TYPE, String.class);
+        if (!SecurityConstants.TOKEN_TYPE_REFRESH.equals(tokenType)) {
+            throw new InvalidTokenException();
+        }
+
+        Set<String> audiences = claims.getAudience();
+        if (audiences == null || !audiences.contains(jwtProperties.getRefreshTokenAudience())) {
+            throw new InvalidTokenException();
+        }
+
+        String subject = claims.getSubject();
+        String tokenId = claims.getId();
+        String email = claims.get(SecurityConstants.CLAIM_EMAIL, String.class);
+
+        return new RefreshTokenClaims(UUID.fromString(subject), tokenId, email);
+    }
+
+    public long getAccessTokenExpirationSeconds() {
+        return jwtProperties.getAccessTokenExpirationSeconds();
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .requireIssuer(jwtProperties.getIssuer())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (JwtException | IllegalArgumentException ex) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    private String buildToken(
+            UUID userId,
+            String audience,
+            String jti,
+            Instant issuedAt,
+            Instant expiresAt,
+            Map<String, Object> claims
+    ) {
+        return Jwts.builder()
+                .claims(claims)
+                .subject(userId.toString())
+                .issuer(jwtProperties.getIssuer())
+                .audience().add(audience).and()
+                .id(jti)
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiresAt))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/org/mangala/authentication/auth/token/RefreshTokenClaims.java
+++ b/src/main/java/org/mangala/authentication/auth/token/RefreshTokenClaims.java
@@ -1,0 +1,10 @@
+package org.mangala.authentication.auth.token;
+
+import java.util.UUID;
+
+public record RefreshTokenClaims(
+        UUID userId,
+        String tokenId,
+        String email
+) {
+}

--- a/src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java
@@ -3,6 +3,11 @@ package org.mangala.authentication.auth.usecase;
 import com.webauthn4j.util.Base64UrlUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.mangala.authentication.auth.adapter.repository.RefreshTokenRepository;
+import org.mangala.authentication.auth.adapter.repository.UserAuthorizationQueryRepository;
+import org.mangala.authentication.auth.domain.RefreshTokenEntity;
+import org.mangala.authentication.auth.token.JwtTokenBundle;
+import org.mangala.authentication.auth.token.JwtTokenService;
 import org.mangala.authentication.auth.usecase.command.CompleteAuthenticationCommand;
 import org.mangala.authentication.auth.usecase.model.CompleteAuthenticationResponse;
 import org.mangala.authentication.passkey.domain.InvalidChallengeTypeException;
@@ -25,7 +30,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+import java.time.ZoneOffset;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -38,6 +44,9 @@ public class CompleteAuthenticationUseCaseImpl implements CompleteAuthentication
     private final UpdatePasskeySignCountUseCase updatePasskeySignCountUseCase;
     private final UserRepository userRepository;
     private final WebAuthnConfigProperties webAuthnConfig;
+    private final JwtTokenService jwtTokenService;
+    private final UserAuthorizationQueryRepository authorizationQueryRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     @Transactional
@@ -101,25 +110,32 @@ public class CompleteAuthenticationUseCaseImpl implements CompleteAuthentication
         UserEntity user = userRepository.findById(passkey.getUserId())
                 .orElseThrow(UserNotFoundException::new);
 
-        // TODO: Generate JWT tokens using common-security module
-        // For now, return placeholder values
-        String accessToken = generatePlaceholderToken(user.getId(), "access");
-        String refreshToken = generatePlaceholderToken(user.getId(), "refresh");
+        List<String> roles = authorizationQueryRepository.findRolesByUserId(user.getId());
+        List<String> permissions = authorizationQueryRepository.findPermissionsByUserId(user.getId());
+
+        JwtTokenBundle tokenBundle = jwtTokenService.issueTokenPair(
+                user.getId(),
+                user.getEmail(),
+                roles,
+                permissions
+        );
+
+        RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity();
+        refreshTokenEntity.setTokenId(tokenBundle.refreshTokenId());
+        refreshTokenEntity.setUserId(user.getId());
+        refreshTokenEntity.setExpiresAt(LocalDateTime.ofInstant(tokenBundle.refreshExpiresAt(), ZoneOffset.UTC));
+        refreshTokenEntity.setCreatedAt(LocalDateTime.now(ZoneOffset.UTC));
+        refreshTokenRepository.save(refreshTokenEntity);
 
         log.info("Authentication completed successfully for user: {}", user.getEmail());
 
         return new CompleteAuthenticationResponse(
-                accessToken,
-                refreshToken,
+                tokenBundle.accessToken(),
+                tokenBundle.refreshToken(),
                 "Bearer",
-                3600L, // 1 hour
+                tokenBundle.accessExpiresInSeconds(),
                 user.getId(),
                 user.getEmail()
         );
-    }
-
-    private String generatePlaceholderToken(UUID userId, String type) {
-        // TODO: Replace with actual JWT generation from common-security module
-        return "placeholder_" + type + "_token_for_" + userId;
     }
 }

--- a/src/main/java/org/mangala/authentication/auth/usecase/RefreshTokenUseCase.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/RefreshTokenUseCase.java
@@ -1,0 +1,9 @@
+package org.mangala.authentication.auth.usecase;
+
+import org.mangala.authentication.auth.usecase.command.RefreshTokenCommand;
+import org.mangala.authentication.auth.usecase.model.CompleteAuthenticationResponse;
+
+public interface RefreshTokenUseCase {
+
+    CompleteAuthenticationResponse execute(RefreshTokenCommand command);
+}

--- a/src/main/java/org/mangala/authentication/auth/usecase/RefreshTokenUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/RefreshTokenUseCaseImpl.java
@@ -1,0 +1,83 @@
+package org.mangala.authentication.auth.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.mangala.authentication.auth.adapter.repository.RefreshTokenRepository;
+import org.mangala.authentication.auth.adapter.repository.UserAuthorizationQueryRepository;
+import org.mangala.authentication.auth.domain.RefreshTokenEntity;
+import org.mangala.authentication.auth.domain.RefreshTokenNotFoundException;
+import org.mangala.authentication.auth.domain.RefreshTokenRevokedException;
+import org.mangala.authentication.auth.token.JwtTokenBundle;
+import org.mangala.authentication.auth.token.JwtTokenService;
+import org.mangala.authentication.auth.token.RefreshTokenClaims;
+import org.mangala.authentication.auth.usecase.command.RefreshTokenCommand;
+import org.mangala.authentication.auth.usecase.model.CompleteAuthenticationResponse;
+import org.mangala.authentication.user.adapter.repository.UserRepository;
+import org.mangala.authentication.user.domain.UserEntity;
+import org.mangala.authentication.user.domain.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenUseCaseImpl implements RefreshTokenUseCase {
+
+    private final JwtTokenService jwtTokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final UserAuthorizationQueryRepository authorizationQueryRepository;
+
+    @Override
+    @Transactional
+    public CompleteAuthenticationResponse execute(RefreshTokenCommand command) {
+        RefreshTokenClaims claims = jwtTokenService.parseAndValidateRefreshToken(command.refreshToken());
+
+        RefreshTokenEntity currentToken = refreshTokenRepository.findByTokenId(claims.tokenId())
+                .orElseThrow(RefreshTokenNotFoundException::new);
+
+        if (currentToken.getRevokedAt() != null) {
+            throw new RefreshTokenRevokedException();
+        }
+
+        if (currentToken.getExpiresAt().isBefore(LocalDateTime.now(ZoneOffset.UTC))) {
+            currentToken.setRevokedAt(LocalDateTime.now(ZoneOffset.UTC));
+            refreshTokenRepository.save(currentToken);
+            throw new RefreshTokenRevokedException();
+        }
+
+        UserEntity user = userRepository.findById(claims.userId())
+                .orElseThrow(UserNotFoundException::new);
+
+        List<String> roles = authorizationQueryRepository.findRolesByUserId(user.getId());
+        List<String> permissions = authorizationQueryRepository.findPermissionsByUserId(user.getId());
+
+        JwtTokenBundle tokenBundle = jwtTokenService.issueTokenPair(
+                user.getId(),
+                user.getEmail(),
+                roles,
+                permissions
+        );
+
+        currentToken.setRevokedAt(LocalDateTime.now(ZoneOffset.UTC));
+        refreshTokenRepository.save(currentToken);
+
+        RefreshTokenEntity newRefreshToken = new RefreshTokenEntity();
+        newRefreshToken.setTokenId(tokenBundle.refreshTokenId());
+        newRefreshToken.setUserId(user.getId());
+        newRefreshToken.setExpiresAt(LocalDateTime.ofInstant(tokenBundle.refreshExpiresAt(), ZoneOffset.UTC));
+        newRefreshToken.setCreatedAt(LocalDateTime.now(ZoneOffset.UTC));
+        refreshTokenRepository.save(newRefreshToken);
+
+        return new CompleteAuthenticationResponse(
+                tokenBundle.accessToken(),
+                tokenBundle.refreshToken(),
+                "Bearer",
+                tokenBundle.accessExpiresInSeconds(),
+                user.getId(),
+                user.getEmail()
+        );
+    }
+}

--- a/src/main/java/org/mangala/authentication/auth/usecase/command/RefreshTokenCommand.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/command/RefreshTokenCommand.java
@@ -1,0 +1,6 @@
+package org.mangala.authentication.auth.usecase.command;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenCommand(@NotBlank String refreshToken) {
+}

--- a/src/main/java/org/mangala/authentication/shared/config/security/InternalApiSecurityConfig.java
+++ b/src/main/java/org/mangala/authentication/shared/config/security/InternalApiSecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableConfigurationProperties(InternalApiSecurityProperties.class)
+@EnableConfigurationProperties({InternalApiSecurityProperties.class, JwtProperties.class})
 public class InternalApiSecurityConfig {
 
     private static final String INTERNAL_POLICY_READ_AUTHORITY = "INTERNAL_POLICY_READ";

--- a/src/main/java/org/mangala/authentication/shared/config/security/JwtProperties.java
+++ b/src/main/java/org/mangala/authentication/shared/config/security/JwtProperties.java
@@ -1,0 +1,33 @@
+package org.mangala.authentication.shared.config.security;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "application.authentication.jwt")
+public class JwtProperties {
+
+    @NotBlank
+    private String secret;
+
+    @NotBlank
+    private String issuer;
+
+    @NotBlank
+    private String accessTokenAudience;
+
+    @NotBlank
+    private String refreshTokenAudience;
+
+    @Min(60)
+    private long accessTokenExpirationSeconds;
+
+    @Min(300)
+    private long refreshTokenExpirationSeconds;
+}

--- a/src/main/java/org/mangala/authentication/shared/exception/ErrorConstant.java
+++ b/src/main/java/org/mangala/authentication/shared/exception/ErrorConstant.java
@@ -28,7 +28,12 @@ public enum ErrorConstant implements ErrorDefinition {
     NO_PASSKEYS_FOUND(HttpStatus.BAD_REQUEST, "0000011", "No passkeys registered for this user."),
     ASSERTION_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "0000012", "Authentication assertion verification failed."),
     SIGN_COUNT_MISMATCH(HttpStatus.UNAUTHORIZED, "0000013", "Sign count mismatch detected. Possible cloned authenticator."),
-    INVALID_CHALLENGE_TYPE(HttpStatus.BAD_REQUEST, "0000014", "Invalid challenge type for operation.");
+    INVALID_CHALLENGE_TYPE(HttpStatus.BAD_REQUEST, "0000014", "Invalid challenge type for operation."),
+
+    // Token errors
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "0000015", "Token is invalid or expired."),
+    REFRESH_TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "0000016", "Refresh token has been revoked."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "0000017", "Refresh token not found.");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/org/mangala/authentication/user/usecase/CreateUserUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/user/usecase/CreateUserUseCaseImpl.java
@@ -1,6 +1,7 @@
 package org.mangala.authentication.user.usecase;
 
 import lombok.RequiredArgsConstructor;
+import org.mangala.authentication.auth.adapter.repository.UserAuthorizationQueryRepository;
 import org.mangala.authentication.user.adapter.repository.UserRepository;
 import org.mangala.authentication.user.domain.UserEntity;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import java.util.UUID;
 public class CreateUserUseCaseImpl implements CreateUserUseCase {
 
     private final UserRepository userRepository;
+    private final UserAuthorizationQueryRepository authorizationQueryRepository;
 
     @Override
     public UserEntity execute(String email, UUID userId) {
@@ -31,6 +33,8 @@ public class CreateUserUseCaseImpl implements CreateUserUseCase {
 
         user.setCreatedAt(LocalDateTime.now());
 
-        return userRepository.save(user);
+        UserEntity persisted = userRepository.save(user);
+        authorizationQueryRepository.assignDefaultRole(persisted.getId());
+        return persisted;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,13 @@ spring:
 
 application:
   authentication:
+    jwt:
+      secret: ${JWT_SECRET:your-256-bit-secret-key-for-jwt-signing-replace-in-production}
+      issuer: ${JWT_ISSUER:mangala}
+      access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:900}
+      refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:604800}
+      refresh-token-audience: ${JWT_REFRESH_AUDIENCE:mangala-auth-refresh}
+      access-token-audience: ${JWT_ACCESS_AUDIENCE:mangala-gateway}
     passkey:
       rp:
         id: ${RP_ID}

--- a/src/main/resources/migration/V7__create_refresh_tokens_table.sql
+++ b/src/main/resources/migration/V7__create_refresh_tokens_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_id varchar(64) NOT NULL UNIQUE,
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at timestamp NOT NULL,
+    revoked_at timestamp,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
+CREATE INDEX idx_refresh_tokens_revoked_at ON refresh_tokens(revoked_at);

--- a/src/test/java/org/mangala/authentication/auth/token/JwtTokenServiceTest.java
+++ b/src/test/java/org/mangala/authentication/auth/token/JwtTokenServiceTest.java
@@ -1,0 +1,83 @@
+package org.mangala.authentication.auth.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mangala.authentication.auth.domain.InvalidTokenException;
+import org.mangala.authentication.shared.config.security.JwtProperties;
+import org.mangala.security.SecurityConstants;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtTokenServiceTest {
+
+    private JwtTokenService jwtTokenService;
+    private JwtProperties jwtProperties;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = new JwtProperties();
+        jwtProperties.setSecret("test-secret-key-with-minimum-32-bytes-for-hmac-12345");
+        jwtProperties.setIssuer("mangala");
+        jwtProperties.setAccessTokenAudience("mangala-gateway");
+        jwtProperties.setRefreshTokenAudience("mangala-auth-refresh");
+        jwtProperties.setAccessTokenExpirationSeconds(900);
+        jwtProperties.setRefreshTokenExpirationSeconds(604800);
+        jwtTokenService = new JwtTokenService(jwtProperties);
+    }
+
+    @Test
+    void shouldIssueValidAccessAndRefreshTokenPair() {
+        UUID userId = UUID.randomUUID();
+
+        JwtTokenBundle bundle = jwtTokenService.issueTokenPair(
+                userId,
+                "user@example.com",
+                List.of("ROLE_USER"),
+                List.of("wallets:read")
+        );
+
+        Claims accessClaims = parseClaims(bundle.accessToken());
+
+        assertEquals(userId.toString(), accessClaims.getSubject());
+        assertEquals("mangala", accessClaims.getIssuer());
+        assertEquals(SecurityConstants.TOKEN_TYPE_ACCESS, accessClaims.get(SecurityConstants.CLAIM_TOKEN_TYPE, String.class));
+        assertEquals("user@example.com", accessClaims.get(SecurityConstants.CLAIM_EMAIL, String.class));
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = accessClaims.get(SecurityConstants.CLAIM_ROLES, List.class);
+        assertTrue(roles.contains("ROLE_USER"));
+
+        RefreshTokenClaims refreshTokenClaims = jwtTokenService.parseAndValidateRefreshToken(bundle.refreshToken());
+        assertEquals(userId, refreshTokenClaims.userId());
+        assertEquals(bundle.refreshTokenId(), refreshTokenClaims.tokenId());
+        assertEquals("user@example.com", refreshTokenClaims.email());
+    }
+
+    @Test
+    void shouldRejectAccessTokenWhenUsedAsRefreshToken() {
+        JwtTokenBundle bundle = jwtTokenService.issueTokenPair(
+                UUID.randomUUID(),
+                "user@example.com",
+                List.of("ROLE_USER"),
+                List.of()
+        );
+
+        assertThrows(InvalidTokenException.class, () -> jwtTokenService.parseAndValidateRefreshToken(bundle.accessToken()));
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8)))
+                .requireIssuer(jwtProperties.getIssuer())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}


### PR DESCRIPTION
## Analysis Summary
This PR implements issue #9 by replacing placeholder token generation with production-ready JWT issuance in `mangala-authentication`, and adds refresh-token rotation support.

### Problem statement
`authenticate:complete` previously returned placeholder strings, which blocked production authn/authz and prevented real gateway verification.

### Impact
- Enables signed JWT-based authentication end-to-end.
- Aligns auth service token contract with gateway validation behavior.
- Introduces refresh-token persistence and rotation baseline.

### Success signal
- `POST /v1/authenticate/passkeys:complete` returns signed access/refresh JWT.
- `POST /v1/auth/refresh` rotates refresh token and returns a new pair.
- Context sync check passes after schema and contract changes.

## Scope and Acceptance Criteria
### In scope
- JWT issuing service with configured issuer/audience/expiry.
- Replace placeholder token logic in complete-auth use case.
- Refresh token persistence (`refresh_tokens`) + rotate-on-refresh flow.
- Add refresh endpoint and token-related error handling.
- Update context documentation for schema/contract changes.

### Out of scope
- Full OAuth/OIDC provider capabilities.
- Enterprise key management (KMS/HSM).
- Full e2e runtime validation in this environment.

### Acceptance criteria mapping
- [x] Signed access/refresh token pair returned from `authenticate:complete`.
- [x] Access token includes operational claims (`iss/sub/aud/iat/exp/jti/type` + user authz claims).
- [x] Refresh token validation enforces type/audience/signature/issuer.
- [x] Refresh rotation implemented (old token revoked, new token stored/returned).
- [x] Context sync checks updated and passing.

## Selected Diagram Set
- **Sequence diagram (Mermaid)** only.
- Reason: This change is integration-heavy (Client -> Gateway -> Auth -> DB token store) with clear success/failure branching.

## Diagrams
```mermaid
sequenceDiagram
  participant C as Client
  participant G as Gateway
  participant A as Auth Service
  participant DB as Auth DB (refresh_tokens)

  C->>G: POST /api/v1/authenticate/passkeys:complete
  G->>A: Forward /v1/authenticate/passkeys:complete
  A->>A: Verify passkey assertion
  A->>A: Build claims and sign access/refresh JWT
  A->>DB: Insert refresh token metadata (jti, user, expiry)
  A-->>G: 200 accessToken + refreshToken
  G-->>C: 200 token pair

  C->>G: POST /api/v1/auth/refresh (refreshToken)
  G->>A: Forward /v1/auth/refresh
  A->>A: Validate refresh JWT (sig/iss/aud/type/exp)
  A->>DB: Lookup token_id and verify not revoked
  A->>DB: Revoke old token_id
  A->>A: Issue new access/refresh JWT
  A->>DB: Insert new refresh token metadata
  A-->>G: 200 new token pair
  G-->>C: 200 new token pair
```

## What changed
### Auth token issuance
- Replaced placeholder token generation in `CompleteAuthenticationUseCaseImpl`.
- Added `JwtTokenService`, `JwtTokenBundle`, `RefreshTokenClaims`.
- Added JWT config properties in `application.yml` and `sample.env`.

### Refresh token flow
- Added migration `V7__create_refresh_tokens_table.sql`.
- Added `RefreshTokenEntity` + `RefreshTokenRepository`.
- Added `RefreshTokenUseCase` + implementation + command + request DTO.
- Added endpoint `POST /v1/auth/refresh` in `AuthController`.

### Authorization claims support
- Added `UserAuthorizationQueryRepository` to load roles/permissions.
- Updated user creation to assign default role `ROLE_USER`.

### Error handling
- Added token-related errors in `ErrorConstant` and domain exceptions.

### Dependencies
- Added `jjwt-api`, `jjwt-impl`, `jjwt-jackson`.

### Context docs
- Updated `docs/context-map.yaml` and verified context sync script.

## Testing
### Executed
- `mvn -q -DskipTests compile` ✅
- `mvn -q -Dtest=JwtTokenServiceTest test` ✅
- `scripts/check-context-sync.sh` ✅

### Not fully executed in this environment
- Full `mvn test` suite ❌ due to Docker/Testcontainers and JVM attach limitations in sandbox.

## Open Questions and Risks
### Open questions
- MVP signing strategy for future hardening (HS256 now vs RS256 later).
- Long-term choice: embed full permissions in JWT vs derive at runtime.
- Refresh token cleanup/retention policy.

### Risks
- Misaligned issuer/audience/secret between auth and gateway may produce broad `401`.
- Revocation surface is currently focused on refresh rotation path only.
