### PR TITLE
feat(auth): finalize refresh token contract behavior

### DIFF
--- a/docs/context-map.yaml
+++ b/docs/context-map.yaml
@@ -54,6 +54,12 @@ security_and_permissions:
     - method: POST
       path: /v1/auth/refresh
       purpose: rotate refresh token and return a new access/refresh token pair
+      response_fields:
+        - accessToken
+        - refreshToken
+        - tokenType
+        - expiresIn
+        - refreshExpiresIn
   jwt_contract:
     access_token_claims:
       - iss

--- a/src/main/java/org/mangala/authentication/auth/adapter/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/repository/RefreshTokenRepository.java
@@ -1,12 +1,17 @@
 package org.mangala.authentication.auth.adapter.repository;
 
 import org.mangala.authentication.auth.domain.RefreshTokenEntity;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
 
     Optional<RefreshTokenEntity> findByTokenId(String tokenId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<RefreshTokenEntity> findWithLockByTokenId(String tokenId);
 }

--- a/src/main/java/org/mangala/authentication/auth/adapter/web/dto/CompletePasskeyAuthenticationResponseDTO.java
+++ b/src/main/java/org/mangala/authentication/auth/adapter/web/dto/CompletePasskeyAuthenticationResponseDTO.java
@@ -17,6 +17,9 @@ public record CompletePasskeyAuthenticationResponseDTO(
         @JsonProperty("expiresIn")
         long expiresIn,
 
+        @JsonProperty("refreshExpiresIn")
+        long refreshExpiresIn,
+
         @JsonProperty("userId")
         UUID userId,
 

--- a/src/main/java/org/mangala/authentication/auth/token/JwtTokenBundle.java
+++ b/src/main/java/org/mangala/authentication/auth/token/JwtTokenBundle.java
@@ -7,6 +7,7 @@ public record JwtTokenBundle(
         String refreshToken,
         String refreshTokenId,
         long accessExpiresInSeconds,
+        long refreshExpiresInSeconds,
         Instant refreshExpiresAt
 ) {
 }

--- a/src/main/java/org/mangala/authentication/auth/token/JwtTokenService.java
+++ b/src/main/java/org/mangala/authentication/auth/token/JwtTokenService.java
@@ -70,6 +70,7 @@ public class JwtTokenService {
                 refreshToken,
                 refreshJti,
                 jwtProperties.getAccessTokenExpirationSeconds(),
+                jwtProperties.getRefreshTokenExpirationSeconds(),
                 refreshExpiry
         );
     }

--- a/src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/CompleteAuthenticationUseCaseImpl.java
@@ -134,6 +134,7 @@ public class CompleteAuthenticationUseCaseImpl implements CompleteAuthentication
                 tokenBundle.refreshToken(),
                 "Bearer",
                 tokenBundle.accessExpiresInSeconds(),
+                tokenBundle.refreshExpiresInSeconds(),
                 user.getId(),
                 user.getEmail()
         );

--- a/src/main/java/org/mangala/authentication/auth/usecase/RefreshTokenUseCaseImpl.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/RefreshTokenUseCaseImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.mangala.authentication.auth.adapter.repository.RefreshTokenRepository;
 import org.mangala.authentication.auth.adapter.repository.UserAuthorizationQueryRepository;
 import org.mangala.authentication.auth.domain.RefreshTokenEntity;
+import org.mangala.authentication.auth.domain.InvalidTokenException;
 import org.mangala.authentication.auth.domain.RefreshTokenNotFoundException;
 import org.mangala.authentication.auth.domain.RefreshTokenRevokedException;
 import org.mangala.authentication.auth.token.JwtTokenBundle;
@@ -35,8 +36,12 @@ public class RefreshTokenUseCaseImpl implements RefreshTokenUseCase {
     public CompleteAuthenticationResponse execute(RefreshTokenCommand command) {
         RefreshTokenClaims claims = jwtTokenService.parseAndValidateRefreshToken(command.refreshToken());
 
-        RefreshTokenEntity currentToken = refreshTokenRepository.findByTokenId(claims.tokenId())
+        RefreshTokenEntity currentToken = refreshTokenRepository.findWithLockByTokenId(claims.tokenId())
                 .orElseThrow(RefreshTokenNotFoundException::new);
+
+        if (!currentToken.getUserId().equals(claims.userId())) {
+            throw new InvalidTokenException();
+        }
 
         if (currentToken.getRevokedAt() != null) {
             throw new RefreshTokenRevokedException();
@@ -76,6 +81,7 @@ public class RefreshTokenUseCaseImpl implements RefreshTokenUseCase {
                 tokenBundle.refreshToken(),
                 "Bearer",
                 tokenBundle.accessExpiresInSeconds(),
+                tokenBundle.refreshExpiresInSeconds(),
                 user.getId(),
                 user.getEmail()
         );

--- a/src/main/java/org/mangala/authentication/auth/usecase/model/CompleteAuthenticationResponse.java
+++ b/src/main/java/org/mangala/authentication/auth/usecase/model/CompleteAuthenticationResponse.java
@@ -7,6 +7,7 @@ public record CompleteAuthenticationResponse(
         String refreshToken,
         String tokenType,
         long expiresIn,
+        long refreshExpiresIn,
         UUID userId,
         String email
 ) {

--- a/src/test/java/org/mangala/authentication/auth/token/JwtTokenServiceTest.java
+++ b/src/test/java/org/mangala/authentication/auth/token/JwtTokenServiceTest.java
@@ -10,6 +10,8 @@ import org.mangala.authentication.shared.config.security.JwtProperties;
 import org.mangala.security.SecurityConstants;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -70,6 +72,38 @@ class JwtTokenServiceTest {
         );
 
         assertThrows(InvalidTokenException.class, () -> jwtTokenService.parseAndValidateRefreshToken(bundle.accessToken()));
+    }
+
+    @Test
+    void shouldRejectRefreshTokenWithWrongAudience() {
+        String token = Jwts.builder()
+                .subject(UUID.randomUUID().toString())
+                .issuer(jwtProperties.getIssuer())
+                .audience().add("wrong-audience").and()
+                .id(UUID.randomUUID().toString())
+                .claim(SecurityConstants.CLAIM_TOKEN_TYPE, SecurityConstants.TOKEN_TYPE_REFRESH)
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plusSeconds(3600)))
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8)))
+                .compact();
+
+        assertThrows(InvalidTokenException.class, () -> jwtTokenService.parseAndValidateRefreshToken(token));
+    }
+
+    @Test
+    void shouldRejectRefreshTokenWithWrongIssuer() {
+        String token = Jwts.builder()
+                .subject(UUID.randomUUID().toString())
+                .issuer("another-issuer")
+                .audience().add(jwtProperties.getRefreshTokenAudience()).and()
+                .id(UUID.randomUUID().toString())
+                .claim(SecurityConstants.CLAIM_TOKEN_TYPE, SecurityConstants.TOKEN_TYPE_REFRESH)
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plusSeconds(3600)))
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8)))
+                .compact();
+
+        assertThrows(InvalidTokenException.class, () -> jwtTokenService.parseAndValidateRefreshToken(token));
     }
 
     private Claims parseClaims(String token) {


### PR DESCRIPTION
## Summary
This PR finalizes refresh-token contract behavior for MVP by hardening refresh validation, improving concurrency safety, and clarifying response contract.

Closes #11

## What Changed
- Added pessimistic row lock for refresh token lookup:
  - `RefreshTokenRepository.findWithLockByTokenId(...)` with `PESSIMISTIC_WRITE`
- Added ownership verification:
  - ensure `refresh_tokens.user_id` matches JWT `sub`; mismatch -> `InvalidTokenException`
- Extended auth response contract:
  - add `refreshExpiresIn` to response model/DTO
- Wired refresh TTL values through issuance flow:
  - `JwtTokenBundle` now includes `refreshExpiresInSeconds`
  - login and refresh responses return both `expiresIn` and `refreshExpiresIn`
- Increased token contract tests:
  - reject refresh token with wrong audience
  - reject refresh token with wrong issuer
- Updated context docs:
  - `docs/context-map.yaml` includes refresh response fields

## Why
Current refresh flow worked at core level, but lacked contract completeness and some defensive guarantees (ownership check, lock-based race mitigation, explicit refresh TTL response).

## Validation
- `mvn -DskipTests compile` ✅
- `mvn -q -Dtest=JwtTokenServiceTest test` ✅
- `./scripts/check-context-sync.sh` ✅

## Notes
- Untracked local file `.DS_Store` is intentionally excluded from this PR.
